### PR TITLE
Adding support for cpm, CDseq and momf

### DIFF
--- a/pipeline/bin/computeSignaturesNF.R
+++ b/pipeline/bin/computeSignaturesNF.R
@@ -38,9 +38,13 @@ source(paste0(baseDir, '/bin/utils.R'))
 method_normalizations <- read.table(paste0(baseDir, '/optimal_normalizations.csv'), sep = ',', header = TRUE)
 
 # find method-specific normalizations for sc and bulk
-sc_norm <- method_normalizations[method_normalizations$method == method, 2]
-bulk_norm <- method_normalizations[method_normalizations$method == method, 3]
-print(paste0('Method: ', method, '; sc-norm: ', sc_norm, '; bulk-norm: ', bulk_norm))
+if(method %in% method_normalizations$method){
+    sc_norm <- method_normalizations[method_normalizations$method == method, 2]
+    bulk_norm <- method_normalizations[method_normalizations$method == method, 3]
+    print(paste0('Method: ', method, '; sc-norm: ', sc_norm, '; bulk-norm: ', bulk_norm))
+} else {
+    stop(paste0('Method ', method, ' is not currently supported. Exiting.')) 
+}
 
 # check if preprocessing has been performed
 if(args$run_preprocessing == 'true'){

--- a/pipeline/bin/utils.R
+++ b/pipeline/bin/utils.R
@@ -257,7 +257,7 @@ signature_workflow_general <- function(sc_matrix, annotations, annotation_catego
       verbose = TRUE
     )
 
-  }else if (method %in% c('autogenes', 'bayesprism', 'bisque', 'music')){
+  }else if (method %in% c('autogenes', 'bayesprism', 'bisque', 'cdseq', 'cpm', 'music')){
     signature <- NULL
       
   } else {
@@ -364,6 +364,15 @@ deconvolution_workflow_general <- function(sc_matrix, annotations, annotation_ca
     )
     unlink(cx_input, recursive=TRUE)
     unlink(cx_output, recursive=TRUE)
+    
+  } else if (method=="cpm"){
+
+    deconvolution <- omnideconv::deconvolute_cpm(
+      bulk_gene_expression = bulk_matrix, 
+      single_cell_object = sc_matrix, 
+      cell_type_annotations = annotations,
+      verbose = TRUE,
+    )$cellTypePredictions
     
   } else if(method=="dwls") {
     

--- a/pipeline/bin/utils.R
+++ b/pipeline/bin/utils.R
@@ -238,6 +238,14 @@ signature_workflow_general <- function(sc_matrix, annotations, annotation_catego
       verbose = TRUE
     )$basis
     
+  } else if (method == "momf") {
+    
+    signature <- omnideconv::build_model_momf(
+      sc_matrix,
+      annotations,
+      bulk_matrix
+    )
+    
   } else if(method == "scaden"){
     unlink(tmp_dir_path, recursive=TRUE)
     if(!dir.exists(paste0(tmp_dir_path))){
@@ -257,7 +265,7 @@ signature_workflow_general <- function(sc_matrix, annotations, annotation_catego
       verbose = TRUE
     )
 
-  }else if (method %in% c('autogenes', 'bayesprism', 'bisque', 'cdseq', 'cpm', 'music')){
+  } else if (method %in% c('autogenes', 'bayesprism', 'bisque', 'cdseq', 'cpm', 'music')){
     signature <- NULL
       
   } else {
@@ -420,8 +428,18 @@ deconvolution_workflow_general <- function(sc_matrix, annotations, annotation_ca
     #)
     print(deconvolution)
 
-  } else if (method == "music"){
-    deconvolution <- omnideconv::deconvolute_music(
+  } else if (method == "momf"){
+    deconvolution_momf <- omnideconv::deconvolute_momf(
+          bulk_matrix,
+          signature, 
+          sc_matrix, 
+          verbose = TRUE,
+        )
+    
+    deconvolution <- deconvolution_momf$cell.prop
+
+  }  else if (method == "music"){
+    deconvolution <- omnideconv::deconvolute_momf(
       bulk_gene_expression = bulk_matrix, 
       single_cell_object = sc_matrix, 
       cell_type_annotations = annotations,

--- a/pipeline/bin/utils.R
+++ b/pipeline/bin/utils.R
@@ -328,6 +328,21 @@ deconvolution_workflow_general <- function(sc_matrix, annotations, annotation_ca
       batch_ids = sc_batch,
       verbose = TRUE,
     )$bulk.props)
+
+  } else if (method=="cdseq"){
+
+    deconvolution_cdseq <- omnideconv::deconvolute_cdseq(
+      bulk_gene_expression = bulk_matrix, 
+      single_cell_object = sc_matrix, 
+      cell_type_annotations = annotations,
+      batch_ids = sc_batch,
+      block_number=10,
+      gene_subset_size=1000,
+      verbose = TRUE,
+    )
+    
+    deconvolution <- t(deconvolution_cdseq$cdseq_prop_merged)
+    print(deconvolution)
     
   } else if (method=="cibersortx"){
 

--- a/pipeline/optimal_normalizations.csv
+++ b/pipeline/optimal_normalizations.csv
@@ -2,8 +2,12 @@ method,sc_norm,bulk_norm
 autogenes,cpm,tpm
 bayesprism,counts,counts
 bisque,counts,counts
+bseqsc,counts,tpm
+cdseq,counts,counts
 cibersortx,cpm,tpm
+cpm,counts,counts
 dwls,counts,tpm
+momf,counts,counts
 music,counts,tpm
 scaden,counts,tpm
 scdc,counts,tpm

--- a/pipeline/optimal_normalizations.csv
+++ b/pipeline/optimal_normalizations.csv
@@ -2,7 +2,6 @@ method,sc_norm,bulk_norm
 autogenes,cpm,tpm
 bayesprism,counts,counts
 bisque,counts,counts
-bseqsc,counts,tpm
 cdseq,counts,counts
 cibersortx,cpm,tpm
 cpm,counts,counts


### PR DESCRIPTION
Following https://github.com/omnideconv/deconvBench/issues/40

Not entirely sure the signature construction for `momf` is correct, as this method needs counts for bulk normalisation and other method relying on pre-computed signatures need TPM. Please double-check. 